### PR TITLE
fix: Update base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,6 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   // Set base path for GitHub Pages deployment
-  // Change 'greeter' to your actual repository name
-  base: process.env.NODE_ENV === 'production' ? '/greeter/' : '/',
+  // Repository name: mmanna-dev
+  base: process.env.NODE_ENV === 'production' ? '/mmanna-dev/' : '/',
 })


### PR DESCRIPTION
## Description
Corrects path name for Vite to build the page for Github to pick up.

## Type of Change
- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the project's style
- [ ] I have performed a self-review
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Related Issues
<!-- Link related issues: Fixes #123 -->
